### PR TITLE
Build failed: with 'Deploy to Heroku' button

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -88,7 +88,7 @@ cd $BUILD_DIR
 echo "-----> Executing: ./skinny package:standalone"
 ./skinny package:standalone < /dev/null
 
-mv $HOME/.ivy2 $CACHE_DIR/.ivy2
+mv $HOME/.ivy2 $CACHE_DIR/.ivy2 && true
 
 # repack cache
 mkdir -p $CACHE_DIR


### PR DESCRIPTION
I tried heroku-buildpack-skinny out via 'Deploy to Heroku' button.
[Creating a 'Deploy to Heroku' Button | Heroku Dev Center](https://devcenter.heroku.com/articles/heroku-button)

But I met a error at compile phase as below.

```
mv: cannot move ‘/app/.ivy2’ to ‘/app/tmp/cache/.ivy2’: No such file or directory
!     Push rejected, failed to compile Skinny app.
!     Push failed
```

This error occured at `bin/compile`, line: `mv $HOME/.ivy2 $CACHE_DIR/.ivy2` after package:standalone phase.
[heroku-buildpack-skinny/compile at ddbce310ac2cafae9873385828b7ded099855120 · jkutner/heroku-buildpack-skinny](https://github.com/jkutner/heroku-buildpack-skinny/blob/ddbce310ac2cafae9873385828b7ded099855120/bin/compile#L91)

I think that may be continue build even if this error occured.
I got success to deploy to Heroku with my pattched buildpack.

Thanks,
